### PR TITLE
[DevMode] Update to match Discord's updates

### DIFF
--- a/devmode/index.js
+++ b/devmode/index.js
@@ -1,8 +1,20 @@
 import { findByProps } from "@cumcord/modules/webpack";
+import { instead } from "@cumcord/patcher";
+import { showConfirmationModal } from "@cumcord/ui/modals";
 
-const devStore = findByProps("isDeveloper");
+const userMod = findByProps("getUsers");
+const CONNECTION_OPEN = findByProps("isDeveloper")._dispatcher._orderedActionHandlers["CONNECTION_OPEN"];
+try { CONNECTION_OPEN.find(x => x.name === "ExperimentStore").actionHandler({ user: { ...userMod.getCurrentUser(), flags: 1 }, type: "CONNECTION_OPEN" }); } catch (e) {};
 
-Object.defineProperty(devStore, "isDeveloper", { configurable: true, value: true });
+let gcUserPatch = instead("getCurrentUser", userMod, (args, originalFunc) => { return { ...originalFunc(), hasFlag: () => true }});
+CONNECTION_OPEN.find(x => x.name === "DeveloperExperimentStore").actionHandler();
+gcUserPatch();
 
-// i tested, yes this leaves the original intact
-export const onUnload = () => delete devStore.isDeveloper;
+export const onUnload = () => {
+    showConfirmationModal({
+        header: "DevMode",
+        content: "For developer features to be fully disabled, you need to reload Discord.",
+        confirmText: "Reload",
+        type: "Danger"
+    }).then(() => document.location.reload());
+}

--- a/devmode/index.js
+++ b/devmode/index.js
@@ -4,10 +4,10 @@ import { showConfirmationModal } from "@cumcord/ui/modals";
 
 const userMod = findByProps("getUsers");
 const nodes = Object.values(findByProps("isDeveloper")._dispatcher._dependencyGraph.nodes);
-nodes.find(x => x.name === "ExperimentStore").actionHandler["CONNECTION_OPEN"]({ user: { flags: 1 }, type: "CONNECTION_OPEN", experiments: [] });
+try { nodes.find(x => x.name === "ExperimentStore").actionHandler["OVERLAY_INITIALIZE"]({ user: { flags: 1 } }); } catch {};
 
 let gcUserPatch = instead("getCurrentUser", userMod, () => { return { hasFlag: () => true }});
-nodes.find(x => x.name === "DeveloperExperimentStore").actionHandler["CONNECTION_OPEN"]();
+nodes.find(x => x.name === "DeveloperExperimentStore").actionHandler["OVERLAY_INITIALIZE"]();
 gcUserPatch();
 
 export const onUnload = () => {

--- a/devmode/index.js
+++ b/devmode/index.js
@@ -3,11 +3,11 @@ import { instead } from "@cumcord/patcher";
 import { showConfirmationModal } from "@cumcord/ui/modals";
 
 const userMod = findByProps("getUsers");
-const CONNECTION_OPEN = findByProps("isDeveloper")._dispatcher._orderedActionHandlers["CONNECTION_OPEN"];
-try { CONNECTION_OPEN.find(x => x.name === "ExperimentStore").actionHandler({ user: { ...userMod.getCurrentUser(), flags: 1 }, type: "CONNECTION_OPEN" }); } catch (e) {};
+const nodes = Object.values(findByProps("isDeveloper")._dispatcher._dependencyGraph.nodes);
+nodes.find(x => x.name === "ExperimentStore").actionHandler["CONNECTION_OPEN"]({ user: { flags: 1 }, type: "CONNECTION_OPEN", experiments: [] });
 
-let gcUserPatch = instead("getCurrentUser", userMod, (args, originalFunc) => { return { ...originalFunc(), hasFlag: () => true }});
-CONNECTION_OPEN.find(x => x.name === "DeveloperExperimentStore").actionHandler();
+let gcUserPatch = instead("getCurrentUser", userMod, () => { return { hasFlag: () => true }});
+nodes.find(x => x.name === "DeveloperExperimentStore").actionHandler["CONNECTION_OPEN"]();
 gcUserPatch();
 
 export const onUnload = () => {


### PR DESCRIPTION
The new method is entirely different to the old one, and is seemingly impossible to unpatch. As a compromise, the plugin will now display a confirmation message informing the user that they need to reload Discord when the plugin is unloaded.